### PR TITLE
Update gevent's WSGIServer module

### DIFF
--- a/bin/srv.py
+++ b/bin/srv.py
@@ -2,7 +2,7 @@
 # vim: set encoding=utf-8
 
 import gevent
-from gevent.wsgi import WSGIServer
+from gevent.pywsgi import WSGIServer
 from gevent.queue import Queue
 from gevent.monkey import patch_all
 patch_all()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-gevent
+gevent >=1.3.0
 flask
 requests
 python-dateutil


### PR DESCRIPTION
* gevent removed `wsgi` and has an update called `pywsgi` (http://www.gevent.org/changelog.html#b2-2018-05-03, 5th bullet point). The API is similar enough between the 2 modules that simple replacement works.
* Update `srv.py` and `requirements.txt` to correspond to API change